### PR TITLE
Add Rating() support for CVSS 2.0 (#4)

### DIFF
--- a/20/cvss20.go
+++ b/20/cvss20.go
@@ -531,6 +531,23 @@ func (cvss20 CVSS20) EnvironmentalScore() float64 {
 	return roundTo1Decimal((adjustedTemporal + (10-adjustedTemporal)*cdp) * td)
 }
 
+// Rating returns the verbose for a given rating.
+// It does not check wether the number of decimal is valid,
+// as it can differ due to binary imprecisions, and such
+// behaviour is not enforced by the specification.
+func Rating(score float64) (string, error) {
+	if score < 0.0 || score > 10.0 {
+		return "", ErrOutOfBoundsScore
+	}
+	if score >= 7.0 {
+		return "HIGH", nil
+	}
+	if score >= 4.0 {
+		return "MEDIUM", nil
+	}
+	return "LOW", nil
+}
+
 // Helpers to compute CVSS v2.0 scores.
 
 func accessVector(v uint8) float64 {

--- a/20/cvss20_test.go
+++ b/20/cvss20_test.go
@@ -139,6 +139,38 @@ func TestParseVector(t *testing.T) {
 	}
 }
 
+func TestRating(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		Score          float64
+		ExpectedRating string
+		ExpectedErr    error
+	}{
+		"CVE-2021-4131": {
+			Score:          6.8,
+			ExpectedRating: "MEDIUM",
+			ExpectedErr:    nil,
+		},
+		"CVE-2017-17627": {
+			Score:          7.5,
+			ExpectedRating: "HIGH",
+			ExpectedErr:    nil,
+		},
+	}
+
+	for testname, tt := range tests {
+		t.Run(testname, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rating, err := Rating(tt.Score)
+
+			assert.Equal(tt.ExpectedRating, rating)
+			assert.Equal(tt.ExpectedErr, err)
+		})
+	}
+}
+
 func TestScores(t *testing.T) {
 	t.Parallel()
 

--- a/20/errors.go
+++ b/20/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrTooShortVector     = errors.New("too short vector")
 	ErrInvalidMetricOrder = errors.New("invalid metric order")
 	ErrInvalidMetricValue = errors.New("invalid metric value")
+	ErrOutOfBoundsScore   = errors.New("out of bounds score")
 )
 
 // ErrInvalidMetric is an error returned when a given


### PR DESCRIPTION
Adds `Rating()` support for CVSS 2.0 according to NVD Vulnerability Severity Ratings (https://nvd.nist.gov/vuln-metrics/cvss)