### PR TITLE
fix(ci): group all CodeQL action updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # init/autobuild/analyze must stay on the same version or CodeQL errors out
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   
   # Root Go module
   - package-ecosystem: "gomod"


### PR DESCRIPTION
Group CodeQL-related dependabot's PRs so it no longer fails in parallel.