### PR TITLE
fix(#292): shortcut score computation with modified when applicable

### DIFF
--- a/40/cvss40.go
+++ b/40/cvss40.go
@@ -889,24 +889,27 @@ func (cvss40 CVSS40) get(abv string) string {
 // Score returns the CVSS v4.0's score.
 // Use Nomenclature for getting groups used by computation.
 func (cvss40 *CVSS40) Score() float64 {
-	// If the vulnerability does not affect the system AND the subsequent
-	// system, there is no reason to try scoring what has no risk and impact.
-	if cvss40.u1 == 0b10101010 && (cvss40.u2&0b11110000) == 0b10100000 {
-		return 0.0
-	}
-
-	// Get metrics
-	avVal := mod((cvss40.u0&0b11000000)>>6, (cvss40.u3&0b00001110)>>1)
-	acVal := mod((cvss40.u0&0b00100000)>>5, ((cvss40.u3&0b00000001)<<1)|((cvss40.u4&0b10000000)>>7))
-	atVal := mod((cvss40.u0&0b00010000)>>4, (cvss40.u4&0b01100000)>>5)
-	prVal := mod((cvss40.u0&0b00001100)>>2, (cvss40.u4&0b00011000)>>3)
-	uiVal := mod(cvss40.u0&0b00000011, (cvss40.u4&0b00000110)>>1)
+	// Get shortcutable metrics
 	vcVal := mod((cvss40.u1&0b11000000)>>6, ((cvss40.u4&0b00000001)<<1)|((cvss40.u5&0b10000000)>>7))
 	scVal := mod((cvss40.u1&0b00110000)>>4, (cvss40.u5&0b00000110)>>1)
 	viVal := mod((cvss40.u1&0b00001100)>>2, (cvss40.u5&0b01100000)>>5)
 	siVal := mod(cvss40.u1&0b00000011, ((cvss40.u5&0b00000001)<<2)|((cvss40.u6&0b11000000)>>6))
 	vaVal := mod((cvss40.u2&0b11000000)>>6, (cvss40.u5&0b00011000)>>3)
 	saVal := mod((cvss40.u2&0b00110000)>>4, (cvss40.u6&0b00111000)>>3)
+
+	// If the vulnerability does not affect the system AND the subsequent
+	// system, there is no reason to try scoring what has no risk and impact.
+	if vcVal == vscia_n && viVal == vscia_n && vaVal == vscia_n &&
+		scVal == vscia_n && siVal == vscia_n && saVal == vscia_n {
+		return 0.0
+	}
+
+	// Then get all remaining metrics
+	avVal := mod((cvss40.u0&0b11000000)>>6, (cvss40.u3&0b00001110)>>1)
+	acVal := mod((cvss40.u0&0b00100000)>>5, ((cvss40.u3&0b00000001)<<1)|((cvss40.u4&0b10000000)>>7))
+	atVal := mod((cvss40.u0&0b00010000)>>4, (cvss40.u4&0b01100000)>>5)
+	prVal := mod((cvss40.u0&0b00001100)>>2, (cvss40.u4&0b00011000)>>3)
+	uiVal := mod(cvss40.u0&0b00000011, (cvss40.u4&0b00000110)>>1)
 	crVal := cvss40.u2 & 0b00000011
 	if crVal == ciar_x {
 		crVal = ciar_h

--- a/40/cvss40_test.go
+++ b/40/cvss40_test.go
@@ -131,6 +131,30 @@ func TestScore(t *testing.T) {
 			ExpectedScore:        5.8,
 			ExpectedNomenclature: "CVSS-BE",
 		},
+		// The following test cases comes from issue #292.
+		// They cover discrepancies in scoring between the official calulator and go-cvss,
+		// enabled detecting that the bypass was conducted on Base metrics only, while Modified
+		// alternatives could lead to all (M)VC/(M)VI/(M)VA/(M)SC/(M)SI/(M)SA to None (or X).
+		"issue-292-case-1": {
+			CVSS40:               mustParse("CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:P/CR:X/IR:M/AR:X/MAV:N/MAC:H/MAT:X/MPR:L/MUI:X/MVC:L/MVI:N/MVA:H/MSC:L/MSI:S/MSA:S"),
+			ExpectedScore:        7.4,
+			ExpectedNomenclature: "CVSS-BTE",
+		},
+		"issue-292-case-2": {
+			CVSS40:               mustParse("CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:X/CR:H/IR:M/AR:L/MAV:P/MAC:H/MAT:X/MPR:N/MUI:P/MVC:N/MVI:H/MVA:N/MSC:N/MSI:X/MSA:S/S:P/AU:X/R:A/V:X/RE:M/U:Amber"),
+			ExpectedScore:        5.4,
+			ExpectedNomenclature: "CVSS-BE",
+		},
+		"issue-292-case-3": {
+			CVSS40:               mustParse("CVSS:4.0/AV:L/AC:L/AT:N/PR:H/UI:P/VC:H/VI:N/VA:L/SC:H/SI:N/SA:L/E:X/CR:M/IR:H/AR:H/MAV:N/MAC:X/MAT:N/MPR:N/MUI:A/MVC:N/MVI:X/MVA:N/MSC:N/MSI:X/MSA:N"),
+			ExpectedScore:        0.0,
+			ExpectedNomenclature: "CVSS-BE",
+		},
+		"issue-292-case-4": {
+			CVSS40:               mustParse("CVSS:4.0/AV:A/AC:L/AT:P/PR:L/UI:N/VC:N/VI:H/VA:L/SC:N/SI:N/SA:L/E:P/CR:X/IR:L/AR:M/MAV:X/MAC:X/MAT:N/MPR:L/MUI:X/MVC:X/MVI:N/MVA:N/MSC:X/MSI:N/MSA:N/S:P/AU:X/R:A/V:X/RE:M/U:Clear"),
+			ExpectedScore:        0.0,
+			ExpectedNomenclature: "CVSS-BTE",
+		},
 	}
 
 	for testname, tt := range tests {


### PR DESCRIPTION
Fixes the score computation issue where modified metrics did not apply. When the scoring shortcut was followed, it was only on the base metrics thus could lead to invalid scores in case modified alternatives existed.
CVSS-B and CVSS-BE (with or without Supplemental metrics) vectors are not affected by this bug.

Resolves #292